### PR TITLE
handling broken images

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,8 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={"../placeholder.png"}
+        // onError = {(e) => {e.target.onError = null; e.target.src = "../placeholder.png"}}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
Resolving issue #2 

- Handling broken images by changing image's source path on error

![image](https://user-images.githubusercontent.com/61927693/184468331-ea93ddca-a773-4790-8a80-0d2ebe917605.png)

- When user uploads item without image, instead of broken image `placeholder.png` image will be displayed as default

![image](https://user-images.githubusercontent.com/61927693/184468271-cc059389-9fe2-47c8-b241-3f87ec194e72.png)